### PR TITLE
Add global bypass map with pinning

### DIFF
--- a/include/maps.h
+++ b/include/maps.h
@@ -84,6 +84,17 @@ struct panic_flag_map {
 };
 MAP_EXTERN struct panic_flag_map panic_flag MAP_SEC(".maps");
 
+/* Global Suricata bypass flag */
+struct global_bypass_map {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __uint(max_entries, 1);
+        __uint(pinning, LIBBPF_PIN_BY_NAME);
+        __uint(map_flags, BPF_F_RDONLY_PROG);
+        __type(key, __u32);
+        __type(value, __u8);
+};
+MAP_EXTERN struct global_bypass_map global_bypass MAP_SEC(".maps");
+
 /* Whitelist - dynamic, managed from user space */
 struct wl_map {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -221,10 +232,13 @@ struct udp6_flow_map {
 };
 struct icmp_allow_map {
 };
+struct global_bypass_map {
+};
 
 // Dummy map instances
 MAP_EXTERN struct jmp_table_map	  jmp_table;
 MAP_EXTERN struct panic_flag_map  panic_flag;
+MAP_EXTERN struct global_bypass_map global_bypass;
 MAP_EXTERN struct wl_map	  whitelist_map;
 MAP_EXTERN struct ids_flow_v4_map flow_table_v4;
 MAP_EXTERN struct ids_flow_v6_map flow_table_v6;

--- a/src/xdp.c
+++ b/src/xdp.c
@@ -593,8 +593,13 @@ static __always_inline __u32 drop_ipv6_suricata(struct xdp_md* ctx, __u32 is_v6)
 SEC("xdp")
 int xdp_suricata_gate(struct xdp_md* ctx)
 {
-	__u16 proto = 0;
-	__u32 drop  = 0;
+        __u32 idx = 0;
+        const __u8* bypass = bpf_map_lookup_elem(&global_bypass, &idx);
+        if (bypass && *bypass == 1)
+                return XDP_PASS;
+
+        __u16 proto = 0;
+        __u32 drop  = 0;
 
 	bpf_xdp_load_bytes(ctx, ETH_HLEN - 2, &proto, 2);
 

--- a/test/test_xdp.c
+++ b/test/test_xdp.c
@@ -833,15 +833,31 @@ static void test_suricata_gate_bad_ipv6(void** state)
 
 static void test_suricata_gate_bad_ipv4(void** state)
 {
-	(void)state;
-	unsigned char buf[40] = {0};
-	struct xdp_md ctx     = {.data = buf, .data_end = buf + 30};
+        (void)state;
+        unsigned char buf[40] = {0};
+        struct xdp_md ctx     = {.data = buf, .data_end = buf + 30};
 
 	buf[12] = 0x08;
 	buf[13] = 0x00;
 	buf[14] = 0x45;
 
-	assert_int_equal(xdp_suricata_gate(&ctx), XDP_PASS);
+        assert_int_equal(xdp_suricata_gate(&ctx), XDP_PASS);
+}
+
+static void test_suricata_gate_global_bypass(void** state)
+{
+        (void)state;
+        unsigned char buf[64] = {0};
+        struct xdp_md ctx     = {.data = buf, .data_end = buf + sizeof(buf)};
+
+        buf[12] = 0x08;
+        buf[13] = 0x00;
+        buf[14] = 0x45;
+
+        static __u8 flag = 1;
+        mock_map_value = &flag;
+        assert_int_equal(xdp_suricata_gate(&ctx), XDP_PASS);
+        mock_map_value = NULL;
 }
 
 static void test_panic_flag_drop(void** state)
@@ -1148,10 +1164,11 @@ int main(void)
 	    cmocka_unit_test(test_xdp_udp_state_ipv6),
 	    cmocka_unit_test(test_xdp_tcp_state_ipv6),
 	    cmocka_unit_test(test_parse_l2_l3_ipv4),
-	    cmocka_unit_test(test_parse_l2_l3_ipv6),
-	    cmocka_unit_test(test_suricata_gate_bad_ipv6),
-	    cmocka_unit_test(test_suricata_gate_bad_ipv4),
-	    cmocka_unit_test(test_panic_flag_drop),
+            cmocka_unit_test(test_parse_l2_l3_ipv6),
+            cmocka_unit_test(test_suricata_gate_bad_ipv6),
+            cmocka_unit_test(test_suricata_gate_bad_ipv4),
+            cmocka_unit_test(test_suricata_gate_global_bypass),
+            cmocka_unit_test(test_panic_flag_drop),
 	    cmocka_unit_test(test_dynamic_wl),
 	    cmocka_unit_test(test_fastpath_counter),
 	    cmocka_unit_test(test_slowpath_counter),


### PR DESCRIPTION
## Summary
- add pinned `global_bypass` map for Suricata
- short-circuit `xdp_suricata_gate` when bypass is enabled
- cover bypass logic with a new unit test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687fc084c45c8325aa158fcf853fa78e